### PR TITLE
Fixed app/templates/new_domain.j2

### DIFF
--- a/app/templates/new_domain.j2
+++ b/app/templates/new_domain.j2
@@ -1,10 +1,9 @@
-{
+server {
     listen          80;
-    server_name     {{ name }},
-    access_log      logs/{{ name }}.access.log main;
+    server_name     {{ name }};
+    access_log      /tmp/{{ name }}.access.log main;
 
     location / {
-        proxy_pass      http://127.0.0.1:8080;
+        proxy_pass  http://127.0.0.1:8080;
     }
-
 }


### PR DESCRIPTION
Fix invalid Nginx config template and change `access_log` to `/tmp/{{ name }}.access.log` to avoid file permission.


from

```
{
    listen          80;
    server_name     {{ name }},
    access_log      logs/{{ name }}.access.log main;

    location / {
        proxy_pass      http://127.0.0.1:8080;
    }

}
```

to

```
server {
    listen          80;
    server_name     {{ name }};
    access_log      /tmp/{{ name }}.access.log main;

    location / {
        proxy_pass  http://127.0.0.1:8080;
    }
}

```