### PR TITLE
Allows to set a different path for .conf files with CONFIG_PATH env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Table of Contents
   - [Authentication](#authentication)
     - [Configure the auth file](#configure-the-auth-file)
     - [Configure nginx](#configure-nginx)
+    - [Configure .conf file folder](#configure-conf-file-folder)
 
 ## Introduction
 
@@ -114,3 +115,19 @@ server {
 2. Run `nginx -t` to make sure, that your config is valid
 3. Run `systemctl restart nginx` (or equivalent) to restart your nginx and apply the new settings
 4. Your nginx ui is now accessible at nginx.mydomain.com and will correctly prompt for basic auth
+
+### Configure .conf file folder
+
+By default Nginx UI looks for .conf files in `/etc/nginx/conf.d`, but this can be changed by setting the CONFIG_PATH variable in Docker.
+Using `docker-compose.yml` will read the value from the enviroment. If no value is set, the fallback will be the default value.
+
+```bash
+docker run -d --restart=always --name nginxui -v /etc/nginx:/etc/nginx -p 8080:8080 -e CONFIG_PATH=/etc/nginx/conf.d schenkd/nginx-ui:latest
+```
+
+```bash
+export CONFIG_PATH=/etc/nginx/conf.d
+docker-compose up
+```
+
+

--- a/config.py
+++ b/config.py
@@ -5,7 +5,10 @@ class Config(object):
     SECRET_KEY = os.urandom(64).hex()
 
     NGINX_PATH = '/etc/nginx'
-    CONFIG_PATH = os.path.join(NGINX_PATH, 'conf.d')
+    CONFIG_PATH = os.getenv(
+        'CONFIG_PATH', os.path.join(NGINX_PATH, 'conf.d'))
+
+    print(CONFIG_PATH)
 
     @staticmethod
     def init_app(app):

--- a/config.py
+++ b/config.py
@@ -8,8 +8,6 @@ class Config(object):
     CONFIG_PATH = os.getenv(
         'CONFIG_PATH', os.path.join(NGINX_PATH, 'conf.d'))
 
-    print(CONFIG_PATH)
-
     @staticmethod
     def init_app(app):
         pass

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: "3"
 services:
   nginx-ui:
     container_name: nginx-ui
@@ -8,6 +8,8 @@ services:
       - 8080:8080
     volumes:
       - nginx:/etc/nginx
+    environment:
+      - CONFIG_PATH
 
   nginx:
     container_name: nginx


### PR DESCRIPTION
Like [issue 11](https://github.com/schenkd/nginx-ui/issues/11) points out, some nginx installations come directly with a different folder for .conf files, such as `sites-enabled` in ubuntu.
With this the user will be able to simply set an environmental variable to change the default value (`/etc/nginx/conf.d`) for its configuration files.